### PR TITLE
IoProvider: handle connect_error

### DIFF
--- a/packages/socket.io-react-hook/src/IoProvider.tsx
+++ b/packages/socket.io-react-hook/src/IoProvider.tsx
@@ -93,10 +93,12 @@ const IoProvider = function ({ children }: React.PropsWithChildren<{}>) {
       },
     });
 
-    socket.on("error", (error) => {
+    const handleError = (error) => {
       sockets.current[namespaceKey].state.error = error;
       sockets.current[namespaceKey].notify("error");
-    });
+    };
+    socket.on("error", handleError);
+    socket.on("connect_error", handleError);
 
     socket.on("connect", handleConnect);
     socket.on("disconnect", handleDisconnect);


### PR DESCRIPTION
When a socket fails to connect (for example, because the connection was aborted from a middleware on the server), socket.io raises a "connect_error" event, not an "error".

Handle this as well by reporting it through the error state variable.

See also: https://socket.io/docs/v4/middlewares/#handling-middleware-error